### PR TITLE
fix(blog_app_api): fix image upload bugs and serializer read_only_fields

### DIFF
--- a/3. blog_app_api/app/author/serializers.py
+++ b/3. blog_app_api/app/author/serializers.py
@@ -2,15 +2,15 @@ from .models import AuthorModel, BlogPostModel
 from rest_framework import serializers
 
 class AuthorSerializer(serializers.ModelSerializer):
+    """Serializer"""
     user_name = serializers.CharField(
         source='user.username',
         read_only=True,
     )
-    """Serializer"""
     class Meta:
         model = AuthorModel
         fields = ['id', 'name', 'email', 'created_at', 'user', 'user_name']
-        read_only = ['id', 'created_at', 'user', 'user_name']
+        read_only_fields = ['id', 'created_at', 'user', 'user_name']
 
 
 
@@ -23,10 +23,10 @@ class BlogPostSerializer(serializers.ModelSerializer):
     class Meta:
         model = BlogPostModel
         fields = "__all__"
-        read_only = ['id', 'created_at', 'author', 'author_name', 'user']
+        read_only_fields = ['id', 'created_at', 'updated_at', 'author_name', 'user']
 
 class PostImageSerializer(serializers.ModelSerializer):
     class Meta:
         model = BlogPostModel
         fields = ['id', "image"]
-        read_only = ["id"]
+        read_only_fields = ["id"]

--- a/3. blog_app_api/app/author/views.py
+++ b/3. blog_app_api/app/author/views.py
@@ -1,8 +1,7 @@
-from rest_framework import viewsets, views, status
+from rest_framework import viewsets, status
 from .models import AuthorModel, BlogPostModel
 from .serializers import AuthorSerializer, BlogPostSerializer, PostImageSerializer
 from rest_framework.permissions import IsAuthenticated, BasePermission
-from rest_framework.authentication import TokenAuthentication, SessionAuthentication
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.parsers import MultiPartParser, FormParser
@@ -50,5 +49,5 @@ class BlogPostViews(viewsets.ModelViewSet):
             serializer.save()
             return Response(serializer.data, status=status.HTTP_200_OK)
 
-        return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/3. blog_app_api/app/core/urls.py
+++ b/3. blog_app_api/app/core/urls.py
@@ -16,6 +16,8 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
@@ -29,4 +31,4 @@ urlpatterns = [
     path('api/docs/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
     path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh')
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
- Fix NameError crash: HTTP_400_BAD_REQUEST was referenced but never imported; replaced with status.HTTP_400_BAD_REQUEST
- Fix silent security bug: all 3 serializer Meta classes used read_only (ignored by DRF) instead of read_only_fields; user/id/timestamps are now properly enforced as read-only
- Add media URL serving to urls.py so uploaded image URLs resolve correctly via the DRF browsable API and Swagger UI
- Remove unused imports: views, TokenAuthentication, SessionAuthentication

https://claude.ai/code/session_01QxdUp1Ky6QNtYF5BigmjW8